### PR TITLE
docker buildにkaniko buildを使えるようにした

### DIFF
--- a/.deploy/cloud_formation/codebuild.yml
+++ b/.deploy/cloud_formation/codebuild.yml
@@ -20,6 +20,8 @@ Resources:
           - Effect: Allow
             Principal: { Service: ["codebuild.amazonaws.com"] }
             Action: ["sts:AssumeRole"]
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser
       Policies:
         - PolicyName: CodeBuildExecutionBasePolicy
           PolicyDocument:
@@ -89,6 +91,10 @@ Resources:
               commands:
                 - nohup dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375 --storage-driver=overlay2 &
                 - timeout 15s sh -c "until docker info > /dev/null 2>&1; do echo .; sleep 1; done"
+                - credentials=`curl 169.254.170.2$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`
+                - echo "AWS_ACCESS_KEY_ID=$(echo ${credentials} | jq -r .AccessKeyId)" >> /tmp/.awscli-config
+                - echo "AWS_SECRET_ACCESS_KEY=$(echo ${credentials} | jq -r .SecretAccessKey)" >> /tmp/.awscli-config
+                - echo "AWS_SESSION_TOKEN=$(echo ${credentials} | jq -r .Token)" >> /tmp/.awscli-config
             build:
               run-as: runner
               commands:

--- a/kaniko-executor/README.md
+++ b/kaniko-executor/README.md
@@ -1,0 +1,25 @@
+# kaniko-executor
+
+## Inputs
+
+1. `images` (required) : Build image names ('name:tag,name:tag' format)
+2. `cache-repo` (required) : Pushing to docker repository for layer cache
+3. `target` (optional) : Docker build target directory, Defaults to $PWD
+4. `dockerfile` (optional) : Dockerfile name, Defaults to Dockerfile
+
+## Outputs
+
+Return none.
+
+## Example
+
+```yaml
+steps:
+  - uses: actions/checkout@v2
+    with:
+      ref: ${{ github.base_ref }}
+  - uses: rvillage/self_hosted_runner/kaniko-executor@v1-beta
+    with:
+      images: image:tag
+      cache-repo: docker-repository-for-cache
+```

--- a/kaniko-executor/action.yml
+++ b/kaniko-executor/action.yml
@@ -1,0 +1,48 @@
+name: kaniko executor
+description: Exec gcr.io/kaniko-project/executor for docker build
+
+inputs:
+
+  images:
+    description: Build image names ('name:tag,name:tag' format)
+    required: true
+
+  cache-repo:
+    description: Pushing to docker repository for layer cache
+    required: true
+
+  target:
+    description: Docker build target directory, Defaults to $PWD
+    required: false
+    default: '"$PWD"'
+
+  dockerfile:
+    description: Dockerfile name, Defaults to Dockerfile
+    required: false
+    default: Dockerfile
+
+runs:
+
+  using: composite
+  steps:
+    - name: Pull gcr.io/kaniko-project/executor image
+      run: docker pull -q gcr.io/kaniko-project/executor:latest
+      shell: bash
+    - name: Create config.json for Pushing to Amazon ECR
+      run: echo "{\"credsStore\":\"ecr-login\"}" > /tmp/kaniko_config.json
+      shell: bash
+    - name: kaniko executor
+      run: |
+        IFS=, names=(${{ inputs.images }})
+        for name in ${names[*]}; do destination_options+=("--destination" "$name"); done
+
+        docker run --rm \
+          --env-file /tmp/.awscli-config \
+          -v ${{ inputs.target }}:/workspace \
+          -v /tmp/kaniko_config.json:/kaniko/.docker/config.json \
+          gcr.io/kaniko-project/executor:latest \
+            ${destination_options[*]} \
+            --dockerfile ${{ inputs.dockerfile }} \
+            --cache-repo ${{ inputs.cache-repo }} \
+            --cache=true
+      shell: bash


### PR DESCRIPTION
## 参考

- [GoogleContainerTools/kaniko](https://github.com/GoogleContainerTools/kaniko)
- [kanikoをAWS CodeBuildで使う](https://cohalz.co/entry/2019/06/10/100000)
- [IAM Roles for Tasks](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html)
- [AWS CodeBuild を使用して AssumeRole の一時的な認証情報を Docker ランタイムに渡す方法を教えてください。](https://aws.amazon.com/jp/premiumsupport/knowledge-center/codebuild-temporary-credentials-docker/)
- [CodeBuildのビルド内でAssumeRole(クロスアカウントアクセス)する方法とハマった話](https://dev.classmethod.jp/articles/assumerole-in-codebuild/)
- [[小ネタ] CodeBuild に割り当てた IAM Role のクレデンシャルを取得する](https://dev.classmethod.jp/articles/codebuild-iam-role-credential/)